### PR TITLE
250413 remove non-configurable settings

### DIFF
--- a/examples/async_example.py
+++ b/examples/async_example.py
@@ -16,8 +16,7 @@ async def test_async_browser(browser):
     tab = Tab(browser=browser, verbose=False)
     await tab.open()
     res = await tab.query("Search for the capital of the moon?",
-                          model="claude-3-5-sonnet",
-                          planner_mode="agent_s1")
+                          planner_mode="s1")
     print(f"res: {res}")
     await tab.close()
 

--- a/pysimular/browser.py
+++ b/pysimular/browser.py
@@ -13,6 +13,7 @@ class SimularBrowser:
     def __init__(self,
                  path: str,
                  anthropic_key: str = '',
+                 api_keys: dict[str, str] = {},
                  planner_model: str = 'claude-3-5-sonnet',
                  planner_mode: str = 'system_1_2',
                  allow_subtasks: bool = False,
@@ -23,7 +24,9 @@ class SimularBrowser:
 
         Args:
             path (str): Path to the SimularBrowser application
-            anthropic_key (str, optional): Anthropic API key.
+            anthropic_key (str, optional): Anthropic API key (deprecating, use api_keys instead)
+            api_keys (dict[str, str], optional): A map from API provider name to API key, 
+                e.g. {'anthropic': <anthropic_key>, "google": <google_api_key>, "openai": <openai_api_key>}
             planner_model (str, optional): Model to use for planning.
             planner_mode (str, optional): Planning mode to use. Options: system_1, system_2, system_1_2, agent_s1
             allow_subtasks (bool, optional): Whether to allow subtask creation.
@@ -35,6 +38,10 @@ class SimularBrowser:
         self.responses = []
         self.images = [] # base64 string
         self.anthropic_key = anthropic_key
+        self.api_keys = api_keys
+        # Backwards compatibility. Will be removed.
+        if anthropic_key:
+            self.api_keys['anthropic'] = anthropic_key
         self.planner_model = planner_model
         self.planner_mode = planner_mode
         self.allow_subtasks = allow_subtasks
@@ -121,6 +128,7 @@ class SimularBrowser:
         user_info = {
             "message": message,
             "anthropic_key": self.anthropic_key,
+            "api_keys": self.api_keys,
             "planner_model": self.planner_model,
             "planner_mode": self.planner_mode,
             "allow_subtasks": self.allow_subtasks,

--- a/pysimular/browser.py
+++ b/pysimular/browser.py
@@ -12,41 +12,26 @@ class SimularBrowser:
 
     def __init__(self,
                  path: str,
-                 anthropic_key: str = '',
-                 api_keys: dict[str, str] = {},
-                 planner_model: str = 'claude-3-5-sonnet',
-                 planner_mode: str = 'system_1_2',
-                 allow_subtasks: bool = False,
+                 planner_mode: str = 's0',
+                 allow_parallel_browsing: bool = False,
                  max_parallelism: int = 5,
-                 enable_vision: bool = False,
                  max_steps: int = 200):
         """Browser interface for Simular app.
 
         Args:
             path (str): Path to the SimularBrowser application
-            anthropic_key (str, optional): Anthropic API key (deprecating, use api_keys instead)
-            api_keys (dict[str, str], optional): A map from API provider name to API key, 
-                e.g. {'anthropic': <anthropic_key>, "google": <google_api_key>, "openai": <openai_api_key>}
-            planner_model (str, optional): Model to use for planning.
-            planner_mode (str, optional): Planning mode to use. Options: system_1, system_2, system_1_2, agent_s1
-            allow_subtasks (bool, optional): Whether to allow subtask creation.
-            max_parallelism (int, optional): Maximum number of parallel tasks.
-            enable_vision (bool, optional): Whether to enable vision.
+            planner_mode (str, optional): Planning mode to use. Options: s0, s1 (hard-working mode)
+            allow_parallel_browsing (bool, optional): Whether to allow parallel browsing.
+            max_parallelism (int, optional): Maximum number of parallel browser tabs.
+            max_steps (int, optional): Maximum number of agent steps.
         """
         self.app_path = path
         self.completion_event = threading.Event()
         self.responses = []
         self.images = [] # base64 string
-        self.anthropic_key = anthropic_key
-        self.api_keys = api_keys
-        # Backwards compatibility. Will be removed.
-        if anthropic_key:
-            self.api_keys['anthropic'] = anthropic_key
-        self.planner_model = planner_model
         self.planner_mode = planner_mode
-        self.allow_subtasks = allow_subtasks
+        self.allow_parallel_browsing = allow_parallel_browsing
         self.max_parallelism = max_parallelism
-        self.enable_vision = enable_vision
         self.max_steps = max_steps
         self.info = {}
         self.tabs = {}
@@ -127,13 +112,9 @@ class SimularBrowser:
         center = NSDistributedNotificationCenter.defaultCenter()
         user_info = {
             "message": message,
-            "anthropic_key": self.anthropic_key,
-            "api_keys": self.api_keys,
-            "planner_model": self.planner_model,
             "planner_mode": self.planner_mode,
-            "allow_subtasks": self.allow_subtasks,
+            "allow_parallel_browsing": self.allow_parallel_browsing,
             "max_parallelism": self.max_parallelism,
-            "enable_vision": self.enable_vision,
             "max_steps": self.max_steps,
             "reset": reset
         }

--- a/pysimular/tab.py
+++ b/pysimular/tab.py
@@ -157,9 +157,9 @@ class Tab:
                     timeout=600.0):
         self.reset_storage()
         
-        avaliable_planner_modes = ['s0', 's1']
-        if planner_mode not in avaliable_planner_modes:
-            raise ValueError(f"Invalid planner mode: {planner_mode}. Avaliable planner modes: {avaliable_planner_modes}")
+        available_planner_modes = ['s0', 's1']
+        if planner_mode not in available_planner_modes:
+            raise ValueError(f"Invalid planner mode: {planner_mode}. Avaliable planner modes: {available_planner_modes}")
         
         kwargs = {
             'timeout': timeout,

--- a/pysimular/tab.py
+++ b/pysimular/tab.py
@@ -172,6 +172,7 @@ class Tab:
             'query': query,
             'model': model, 
             'anthropic_key': self.browser.anthropic_key,
+            'api_keys': self.browser.api_keys,
             'planner_mode': planner_mode,
             'allow_subtasks': allow_subtasks,
             'max_parallelism': max_parallelism,

--- a/pysimular/tab.py
+++ b/pysimular/tab.py
@@ -150,33 +150,23 @@ class Tab:
     
     async def query(self, 
                     query, 
-                    model: str = 'claude-3-5-sonnet',
-                    planner_mode: str = 'system_1_2',
-                    allow_subtasks: bool = False,
+                    planner_mode: str = 's0',
+                    allow_parallel_browsing: bool = False,
                     max_parallelism: int = 3,
-                    enable_vision: bool = False,
                     max_steps: int = 100,
                     timeout=600.0):
         self.reset_storage()
-
-        avaliable_models = ['claude-3-5-sonnet']
-        if model not in avaliable_models:
-            raise ValueError(f"Invalid model: {model}. Avaliable models: {avaliable_models}")
         
-        avaliable_planner_modes = ['system_1', 'system_2', 'system_1_2', 'agent_s1']
+        avaliable_planner_modes = ['s0', 's1']
         if planner_mode not in avaliable_planner_modes:
             raise ValueError(f"Invalid planner mode: {planner_mode}. Avaliable planner modes: {avaliable_planner_modes}")
         
         kwargs = {
             'timeout': timeout,
             'query': query,
-            'model': model, 
-            'anthropic_key': self.browser.anthropic_key,
-            'api_keys': self.browser.api_keys,
             'planner_mode': planner_mode,
-            'allow_subtasks': allow_subtasks,
+            'allow_parallel_browsing': allow_parallel_browsing,
             'max_parallelism': max_parallelism,
-            'enable_vision': enable_vision,
             'max_steps': max_steps
         }
         await self.post("query", **kwargs)


### PR DESCRIPTION
Removed
* anthropic_key
* planner_model
* enable_vision

Renamed allow_subtasks to allow_parallel_browsing

Options for planner_mode: 's0' and 's1' (hard-working mode)

Compatible with Simular >= 0.10.9 (to be released)